### PR TITLE
issue #47 add firebase and city rank to our model

### DIFF
--- a/assets/js/affordability.js
+++ b/assets/js/affordability.js
@@ -27,6 +27,7 @@ CountyAffordabiity.prototype.getCountyAffordabiityCallback = function(electionDa
 				let medianHomeprice = parseInt(response[i][0]);	// Using median home price as proxy for affordabiltiy.
 				let countyState = response[i][1];
 				// Allow affordability to be looked-up by 'county, state' key.
+				console.log("countyState = ", countyState);
                 that.affordabilityByCounty[countyState] = medianHomeprice;
 			}
         }).fail(function(err) {

--- a/assets/js/city-metrics.js
+++ b/assets/js/city-metrics.js
@@ -36,7 +36,7 @@ let cityMetrics = [
 	{"Pearl City, HI": { "county": "Honolulu County", "happiness": 66.77, "wellbeing": 2, "income_and_employment": 147, "community_and_environment": 15 }},
 	{"Glendale, CA": { "county": "Los Angeles County", "happiness": 66.25, "wellbeing": 27, "income_and_employment": 102, "community_and_environment": 12 }},
 	{"San Diego, CA": { "county": "San Diego County", "happiness": 66.01, "wellbeing": 8, "income_and_employment": 36, "community_and_environment": 46 }},
-	{"St. Paul, MN": { "county": "Ramsey County", "happiness": 65.79, "wellbeing": 18, "income_and_employment": 70, "community_and_environment": 66 }},
+	{"St Paul, MN": { "county": "Ramsey County", "happiness": 65.79, "wellbeing": 18, "income_and_employment": 70, "community_and_environment": 66 }},
 	{"Charleston, SC": { "county": "Charleston County", "happiness": 65.48, "wellbeing": 74, "income_and_employment": 5, "community_and_environment": 4 }},
 	{"Gilbert, AZ": { "county": "Maricopa County", "happiness": 65.07, "wellbeing": 54, "income_and_employment": 48, "community_and_environment": 10 }},
 	{"Anaheim, CA": { "county": "Orange County", "happiness": 65.02, "wellbeing": 29, "income_and_employment": 79, "community_and_environment": 34 }},
@@ -62,7 +62,7 @@ let cityMetrics = [
 	{"Fort Worth, TX": { "county": "Tarrant County", "happiness": 62.35, "wellbeing": 44, "income_and_employment": 90, "community_and_environment": 54 }},
 	{"Burlington, VT": { "county": "Chittenden County", "happiness": 62.31, "wellbeing": 53, "income_and_employment": 10, "community_and_environment": 120 }},
 	{"Peoria, AZ": { "county": "Maricopa County", "happiness": 62.30, "wellbeing": 65, "income_and_employment": 77, "community_and_environment": 23 }},
-	{"Port St. Lucie, FL": { "county": "Lucie County", "happiness": 61.96, "wellbeing": 76, "income_and_employment": 73, "community_and_environment": 13 }},
+	/*{"Port St. Lucie, FL": { "county": "Lucie County", "happiness": 61.96, "wellbeing": 76, "income_and_employment": 73, "community_and_environment": 13 }},*/
 	{"Boise, ID": { "county": "Ada County", "happiness": 61.94, "wellbeing": 68, "income_and_employment": 19, "community_and_environment": 48 }},
 	{"Garland, TX": { "county": "Dallas County", "happiness": 61.86, "wellbeing": 31, "income_and_employment": 120, "community_and_environment": 103 }},
 	{"Aurora, CO": { "county": "Arapahoe County", "happiness": 61.83, "wellbeing": 26, "income_and_employment": 121, "community_and_environment": 104 }},
@@ -83,13 +83,13 @@ let cityMetrics = [
 	{"Rancho Cucamonga, CA": { "county": "San Bernardino County", "happiness": 60.14, "wellbeing": 79, "income_and_employment": 32, "community_and_environment": 68 }},
 	{"Salt Lake City, UT": { "county": "Salt Lake County", "happiness": 60.11, "wellbeing": 80, "income_and_employment": 9, "community_and_environment": 82 }},
 	{"Yonkers, NY": { "county": "Westchester County", "happiness": 60.10, "wellbeing": 45, "income_and_employment": 157, "community_and_environment": 79 }},
-	{"Las Cruces, NM": { "county": "Doqa Ana County", "happiness": 60.08, "wellbeing": 33, "income_and_employment": 123, "community_and_environment": 69 }},
+	/*{"Las Cruces, NM": { "county": "Doqa Ana County", "happiness": 60.08, "wellbeing": 33, "income_and_employment": 123, "community_and_environment": 69 }},*/
 	{"Rapid City, SD": { "county": "Pennington County", "happiness": 60.07, "wellbeing": 86, "income_and_employment": 30, "community_and_environment": 64 }},
 	{"Dallas, TX": { "county": "Dallas County", "happiness": 59.82, "wellbeing": 35, "income_and_employment": 109, "community_and_environment": 123 }},
 	{"South Burlington, VT": { "county": "Chittenden County", "happiness": 59.81, "wellbeing": 90, "income_and_employment": 63, "community_and_environment": 31 }},
 	{"Virginia Beach, VA": { "county": "Virginia Beach city", "happiness": 59.71, "wellbeing": 73, "income_and_employment": 105, "community_and_environment": 43 }},
 	{"Long Beach, CA": { "county": "Los Angeles County", "happiness": 59.58, "wellbeing": 42, "income_and_employment": 138, "community_and_environment": 108 }},
-	{"Anchorage, AK": { "county": "Anchorage Municipality", "happiness": 59.53, "wellbeing": 84, "income_and_employment": 82, "community_and_environment": 41 }},
+	/*{"Anchorage, AK": { "county": "Anchorage Municipality", "happiness": 59.53, "wellbeing": 84, "income_and_employment": 82, "community_and_environment": 41 }},*/
 	{"Cheyenne, WY": { "county": "Laramie County", "happiness": 59.51, "wellbeing": 78, "income_and_employment": 23, "community_and_environment": 127 }},
 	{"Columbia, MD": { "county": "Howard County", "happiness": 59.47, "wellbeing": 49, "income_and_employment": 101, "community_and_environment": 138 }},
 	{"Mesa, AZ": { "county": "Maricopa County", "happiness": 59.25, "wellbeing": 77, "income_and_employment": 116, "community_and_environment": 47 }},
@@ -148,7 +148,7 @@ let cityMetrics = [
 	{"Oklahoma City, OK": { "county": "Oklahoma County", "happiness": 51.59, "wellbeing": 155, "income_and_employment": 110, "community_and_environment": 38 }},
 	{"Corpus Christi, TX": { "county": "Nueces County", "happiness": 51.50, "wellbeing": 145, "income_and_employment": 15, "community_and_environment": 124 }},
 	{"Winston-Salem, NC": { "county": "Forsyth County", "happiness": 51.44, "wellbeing": 116, "income_and_employment": 118, "community_and_environment": 141 }},
-	{"Juneau, AK": { "county": "Juneau City and Borough", "happiness": 51.21, "wellbeing": 160, "income_and_employment": 3, "community_and_environment": 175 }},
+	/*{"Juneau, AK": { "county": "Juneau City and Borough", "happiness": 51.21, "wellbeing": 160, "income_and_employment": 3, "community_and_environment": 175 }},*/
 	{"Albuquerque, NM": { "county": "Bernalillo County", "happiness": 51.15, "wellbeing": 123, "income_and_employment": 111, "community_and_environment": 150 }},
 	{"Columbus, OH": { "county": "Franklin County", "happiness": 51.14, "wellbeing": 128, "income_and_employment": 133, "community_and_environment": 111 }},
 	{"Bakersfield, CA": { "county": "Kern County", "happiness": 50.98, "wellbeing": 139, "income_and_employment": 74, "community_and_environment": 126 }},

--- a/assets/js/city-rank.js
+++ b/assets/js/city-rank.js
@@ -1,3 +1,111 @@
-function CityRank() {
-    let cityMetrics = new CityMetrics();
+function CityRank(dbConfig) {
+    this.ca = new CountyAffordabiity();
+	this.cm = new CityMetrics();
+    this.cp = new CountyPolitics();
+	this.cpFields = ["rep16_frac", "dem16_frac"];
+    this.fb = new Firebase(dbConfig);
+}
+
+CityRank.prototype.normalizeData = function() {
+	
+	// Populate affordability data from endpoint (synchronously).
+	this.ca.getCountyAffordabiityCallback()(); 
+
+	// For each city known to the model, populate normalizedData[]
+	// with the following attributes:
+	//
+	// {"cityState": {"happiness": value, "political": {rep:value, dem:value}, "affordability": value}}
+	
+	let normalizedData = [];
+	while (this.cm.hasMoreItems()) {
+		let index = this.cm.index;
+		 
+	 	let item = this.cm.getNextItem();
+		let cityST = JSON.stringify(this.cm.getCityST(item));
+		let county = this.cm.getCounty(item);
+		let happiness = this.cm.getHappiness(item);
+		let affordability = this.ca.getAffordability(this.cm.getCountyState(item));
+
+		this.cm.setAffordabilityAtIndex(affordability, index);
+
+		let countyState = this.cm.getCountyStateForCountyPolitics(item);
+		politicalJson = this.cp.cherryPickFields(this.cpFields, countyState);
+		this.cm.setPoliticsJsonAtIndex(politicalJson, index);
+
+        let json = this.cm.cherryPickFields(["happiness", "politics", "affordability"], item);
+        let normalizedItem = {};
+        let normalizedCityST = cityST.replace(/St\. /g, "St ");
+		normalizedItem[normalizedCityST] = json;
+		normalizedData.push(normalizedItem);
+	}
+    console.log(normalizedData);
+    return normalizedData;
+}
+
+CityRank.prototype.publishData = function(data) {
+    this.fb.dbSetData(data);
+}
+
+CityRank.prototype.distance = function(v, w) {
+    let squaredDiffs = 0;
+    let distance = NaN;
+    if (v.length == w.length) {
+        for (let i = 0; i < v.length; i++) {
+            squaredDiffs += Math.pow(v[i] - w[i], 2);
+        }
+        distance = Math.sqrt(squaredDiffs);
+    } else {
+        console.log("CityRank.distance() error: input vectors are different lengths.");
+    }
+    return distance;
+}
+
+CityRank.prototype.cityRank = function(userPrefs) {
+    // userPrefs = {"happiness": value,
+    //              "affordability": value,
+    //              "politics": {"rep16_frac": val, "dem16_frac": val}}
+
+    let rankedCities = this.fb.data;
+    console.log("CityRank.cityRank() userPrefs = ", userPrefs);
+    let v = [userPrefs.happiness, userPrefs.affordability, userPrefs.politics.rep16_frac];
+
+    // TODO:
+    //
+    // I think for purposes of rank calculation, we need to normalize all
+    // values between 0 and 100, so that each dimension of preference contributes
+    // equally in the distance calculation.
+    //
+    // This means we'll need to calculate the range of the input data and
+    // scale the smallest item at 0 and largest at 100.
+
+    for (let i = 0; i < rankedCities; i++) {
+        let item = rankedCities[i];
+        // IMPORTANT: Order of picked fields must match order of fields in v.
+        let cityAttr = Object.values(cm.cherryPickFields(["happiness", "affordability", "politics"], item));
+        let w = [cityAttr.happiness, cityAttr.affordability, cityAttr.politics.rep16_frac];
+        let distance = this.distance(v, w);
+        rankedCities["distance"] = distance;
+        console.log("rankedCities = ", rankedCities);
+    }
+    console.log("typeof rankedCities = ", Array.isArray(rankedCities));
+    rankedCities.sort(this.compareDistance);
+    return rankedCities;
+}
+
+CityMetrics.prototype.compareDistance = function(a, b) {
+    let aDistance = a[Object.keys(a)].distance;
+    let bDistance = b[Object.keys(b)].distance;
+    
+    if (aDistance > bDistance) return 1;
+    if (aDistance == bDistance) return 0;
+    if (aDistance < bDistance) return -1;
+}
+
+function UnitTestCityRank() {
+    cr = new CityRank(Firebase.prototype.glennDbConfig);
+    let normalizedData = cr.normalizeData();
+    cr.publishData(normalizedData);
+    let userPrefs = {"happiness": 50, "affordability": 200000, "politics": {"rep16_frac": 25.00}};
+    let rankedCities = cr.cityRank(userPrefs);
+    console.log("ranked cities = ", rankedCities);
 }

--- a/assets/js/firebase.js
+++ b/assets/js/firebase.js
@@ -1,5 +1,5 @@
 function Firebase(dbConfig) {
-    this.expectedDbLength = 182;
+    this.expectedDbLength = 177;
     this.dbConfig = dbConfig;
     this.dbInit();
     this.dbRef = this.getDbRef();
@@ -53,6 +53,7 @@ Firebase.prototype.dbPushData = function(data) {
 }
 
 Firebase.prototype.dbSetData = function(data) {
+    this.setData(data);
     console.log("Firebase.dbSetData()");
     if (this.validInputData(data)) {
         this.dbRef.set(data);

--- a/test-cityrank.html
+++ b/test-cityrank.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Affordability</title>
+    <script
+      src="https://code.jquery.com/jquery-3.4.0.min.js"
+      integrity="sha256-BJeo0qm959uMBGb65z40ejJYGSgR7REI4+CW1fNKwOg="
+      crossorigin="anonymous"
+    ></script>
+    <script src="https://www.gstatic.com/firebasejs/5.10.0/firebase.js"></script>
+    <script src="assets/js/city-metrics.js"></script>
+    <script src="assets/js/county-political.js"></script>
+    <script src="assets/js/county-political-json.js"></script>
+    <script src="assets/js/city-to-county.js"></script>
+    <script src="assets/js/affordability.js"></script>
+    <script src="assets/js/firebase.js"></script>
+    <script src="assets/js/city-rank.js"></script>
+  </head>
+  <body>
+    <p>Open console to see results of CityRank unit test.</p>
+    <script type="text/javascript">
+      UnitTestCityRank();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Resolves #47 

This encompasses all the parameters of interest except job-outlook (which won't be persisted
to firebase anyway) in our data model.

I've been able to persist our data to firebase with the unit test driver.

See: https://console.firebase.google.com/project/city-rank-7a3a2/database/city-rank-7a3a2/data