### PR TITLE
issue #72 subsequent search cities don't change

### DIFF
--- a/assets/js/city-rank.js
+++ b/assets/js/city-rank.js
@@ -79,9 +79,9 @@ CityRank.prototype.cityRank = function(userPrefs) {
     }
     let rankedCities = [];
     if (this.fb.dataFromFB.length == this.fb.expectedDbLength) {
-        rankedCities = this.fb.dataFromFB;
+        rankedCities = this.fb.dataFromFB.slice();
     } else {
-        rankedCities = this.fb.data;
+        rankedCities = this.fb.data.slice();
     }
 
     // TODO: Calculate these dynamically.  For MVP, hardcode is


### PR DESCRIPTION
Resolves #72 

This bug boils down to the nature of arrays in javascript. Turns out that arrays are pass-by-reference structures.
So if you do something like:

let newArray = oldArray;
newArray[0] = 'new_value';

then oldArray[0] == 'new_value' ; !! :-o

So, any mutations to the newArray affect the oldArray too.
In our case, we were shortening the length of the newArray down to some reasonable number of entries to display on the UI (i.e., 10 in our case). This had the side-effect of actually truncating an array deep in the bowels of the firebase model. Not good.

I should have used a getter to return a copy of the array rather than expose the raw array to higher levels of abstraction. The other expedient choice is to return

let rankedList = this.fb.data.slice(); // which returns a copy of the array